### PR TITLE
Merge develop ← bugfix/crawling-likecount-number-format

### DIFF
--- a/WebtoonWebService/src/main/java/com/pknuwws/wws/crawling/CrawlingKakaoWebtoonInfos.java
+++ b/WebtoonWebService/src/main/java/com/pknuwws/wws/crawling/CrawlingKakaoWebtoonInfos.java
@@ -155,7 +155,7 @@ public class CrawlingKakaoWebtoonInfos extends CrawlingWebtoonInfos {
 				.url(url)
 				.thumbnailUrl(thumbnail)
 				.genre(genres)
-				.likeCount(Integer.parseInt(likeCount))
+				.likeCount(Integer.parseInt(likeCount.replaceAll(",", "")))
 				.firstDate(LocalDate.parse(firstDate, dateTimeFormatter))
 				.dayOfWeek(days)
 				.platform("Kakao")

--- a/WebtoonWebService/src/main/java/com/pknuwws/wws/crawling/CrawlingNaverWebtoonInfos.java
+++ b/WebtoonWebService/src/main/java/com/pknuwws/wws/crawling/CrawlingNaverWebtoonInfos.java
@@ -156,7 +156,7 @@ public class CrawlingNaverWebtoonInfos extends CrawlingWebtoonInfos {
 				.url(url)
 				.thumbnailUrl(thumbnail)
 				.genre(genres)
-				.likeCount(Integer.parseInt(likeCount))
+				.likeCount(Integer.parseInt(likeCount.replaceAll(",", "")))
 				.firstDate(LocalDate.parse(firstDate, dateTimeFormatter))
 				.dayOfWeek(days)
 				.platform("Naver")


### PR DESCRIPTION
likeCount를 parseInt 할 때 쉼표를 제거하지 않아서 발생하던 NumberFormatException을 쉼표 지워서 수정했습니다.